### PR TITLE
Output image path as absolute path

### DIFF
--- a/plugins/_Post_Process/_XAI/_Image/SGD_influence.py
+++ b/plugins/_Post_Process/_XAI/_Image/SGD_influence.py
@@ -39,7 +39,7 @@ def func(args):
     ensure_dir(save_dir)
     seeds = [i for i in range(args.n_trials)]
     base_infl_filename, ext = os.path.splitext(
-        os.path.basename(file_dir_dict['infl_filename']))
+        os.path.basename(args.output))
     save_dir = file_dir_dict['save_dir']
     infl_result_paths = []
     try:
@@ -49,6 +49,7 @@ def func(args):
             infl_result_paths.append(infl_result_path)
             file_dir_dict['infl_filename'] = infl_result_path
             model_info_dict['seed'] = seed
+
             # train
             train(model_info_dict, file_dir_dict,
                   calc_infl_with_all_params, need_evaluate)
@@ -58,7 +59,7 @@ def func(args):
         infl, header = calc_result_mean(infl_result_paths)
         # save
         data_type = 'object,int,float,int'
-        save_to_csv(filename=file_dir_dict['infl_filename'], header=header,
+        save_to_csv(filename=args.output, header=header,
                     list_to_save=infl, data_type=data_type)
         logger.log(99, 'SGD influence completed successfully.')
     except KeyboardInterrupt:

--- a/plugins/_Post_Process/_XAI/_Image/tracin_utils/calculate_score.py
+++ b/plugins/_Post_Process/_XAI/_Image/tracin_utils/calculate_score.py
@@ -151,8 +151,9 @@ def calc_infl(args):
     # sort by influence in ascendissng order
     rows = read_csv(args.input_train)
     image_head = rows[0][0]
-    rows = [[r[1]] for r in rows] # remove image rows
-    rows = add_info_to_csv(rows, results["img_path"], image_head, position=0) # add abs image path
+    rows = [[r[1]] for r in rows]  # remove image rows
+    # add abs image path
+    rows = add_info_to_csv(rows, results["img_path"], image_head, position=0)
     rows = add_info_to_csv(rows, results["influence"], "influence", position=0)
     header = rows.pop(0)
     rows = np.array(rows)

--- a/plugins/_Post_Process/_XAI/_Image/tracin_utils/calculate_score.py
+++ b/plugins/_Post_Process/_XAI/_Image/tracin_utils/calculate_score.py
@@ -150,6 +150,9 @@ def calc_infl(args):
 
     # sort by influence in ascendissng order
     rows = read_csv(args.input_train)
+    image_head = rows[0][0]
+    rows = [[r[1]] for r in rows] # remove image rows
+    rows = add_info_to_csv(rows, results["img_path"], image_head, position=0) # add abs image path
     rows = add_info_to_csv(rows, results["influence"], "influence", position=0)
     header = rows.pop(0)
     rows = np.array(rows)


### PR DESCRIPTION
TracIn and SGD Influence plugins output the image paths, but they were written in relative paths.
So, NNC cannot display the image data because the image path is not valid.
This PR fixes this issue by written in absolute paths.