### PR TITLE
fixed docker image-id issue caused by docker cli upgrades.

### DIFF
--- a/tools/AttentionEditor/GNUmakefile
+++ b/tools/AttentionEditor/GNUmakefile
@@ -26,8 +26,8 @@ all-clean: clean
 .PHONY: docker
 docker:
 	mkdir -p dist_electron/tmp
-	docker build docker |tee dist_electron/tmp/docker-build.log
-	cat dist_electron/tmp/docker-build.log |awk 'END{print $$3}' >dist_electron/tmp/docker-image_id.txt
+	echo electron-docker:$$(date +'%Y%m%d%H%M%S') > dist_electron/tmp/docker-image_id.txt
+	docker build -t $$(cat dist_electron/tmp/docker-image_id.txt) docker |tee dist_electron/tmp/docker-build.log
 
 .PHONY: yarn
 yarn: docker


### PR DESCRIPTION
We used the docker image id which was obtained from docker cli output.
But, the output was changed in recently, and the image id was incorrect.
This PR fixes this issue by using predefined tag.