### PR TITLE
fix deprecation on np.int and np.float in numpy

### DIFF
--- a/plugins/_Post_Process/_Fairness/_Evaluation/kl_divergence.py
+++ b/plugins/_Post_Process/_Fairness/_Evaluation/kl_divergence.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Sony Group Corporation.
+# Copyright 2022,2023 Sony Group Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -97,8 +97,8 @@ def get_kl(p, q):
     Returns:
         kl
     """
-    p = np.asarray(p, dtype=np.float)
-    q = np.asarray(q, dtype=np.float)
+    p = np.asarray(p, dtype=np.float64)
+    q = np.asarray(q, dtype=np.float64)
     return np.sum(np.where(p != 0, p * np.log(p / q), 0))
 
 

--- a/plugins/_Post_Process/_Visualization/scatter_plot.py
+++ b/plugins/_Post_Process/_Visualization/scatter_plot.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Sony Group Corporation.
+# Copyright 2021,2022,2023 Sony Group Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ def func(args):
                 marker={
                     'size': 12,
                     'color': cols[2],
-                    'showscale':True})]
+                    'showscale': True})]
     else:
         data = [
             go.Scatter(

--- a/plugins/_Post_Process/_XAI/_Image/lime_utils/lime_func.py
+++ b/plugins/_Post_Process/_XAI/_Image/lime_utils/lime_func.py
@@ -101,7 +101,7 @@ def lime_func(args):
             executor.forward_target.forward(clear_buffer=True)
 
             for m, probability in zip(mask, output_variable.variable_instance.d):
-                m = m.astype(np.int)
+                m = m.astype(np.uint8)
                 mask_and_result.append([m, probability[args.class_index]])
 
             pbar.update(x.shape[0])

--- a/plugins/_Post_Process/_XAI/_Image/tracin_utils/utils.py
+++ b/plugins/_Post_Process/_XAI/_Image/tracin_utils/utils.py
@@ -152,7 +152,7 @@ class BaseLearningRateScheduler(object):
         class EpochStepLearningRateScheduler(BaseLearningRateScheduler):
             def __init__(self, base_lr, decay_at=[30, 60, 80], decay_rate=0.1, warmup_epochs=5):
                 self.base_learning_rate = base_lr
-                self.decay_at = np.asarray(decay_at, dtype=np.int)
+                self.decay_at = np.asarray(decay_at, dtype=np.int32)
                 self.decay_rate = decay_rate
                 self.warmup_epochs = warmup_epochs
 
@@ -249,7 +249,7 @@ class EpochStepLearningRateScheduler(BaseLearningRateScheduler):
     def __init__(self, base_lr, decay_at=[30, 60, 80], decay_rate=0.1, warmup_epochs=5, legacy_warmup=False):
         super().__init__()
         self.base_learning_rate = base_lr
-        self.decay_at = np.asarray(decay_at, dtype=np.int)
+        self.decay_at = np.asarray(decay_at, dtype=np.int32)
         self.decay_rate = decay_rate
         self.warmup_epochs = warmup_epochs
         self.legacy_warmup_denom = 1 if legacy_warmup else 0
@@ -314,7 +314,7 @@ def save_nnp(input, output, batchsize):
             {'name': 'Runtime',
              'network': 'Validation',
              'data': [k for k, _ in input.items()],
-             'output':[k for k, _ in output.items()]}]}
+             'output': [k for k, _ in output.items()]}]}
     return runtime_contents
 
 

--- a/plugins/_Post_Process/_XAI/_Table/shap_tabular_utils/calculate.py
+++ b/plugins/_Post_Process/_XAI/_Table/shap_tabular_utils/calculate.py
@@ -206,8 +206,8 @@ class KernelSHAP:
                 (self.nsamples * self.train_samples, self.num_classes))
             self.ey = np.zeros((self.nsamples, self.num_classes))
 
-            num_subset_sizes = np.int(np.ceil((M - 1) / 2.0))
-            num_paired_subset_sizes = np.int(np.floor((M - 1) / 2.0))
+            num_subset_sizes = np.int64(np.ceil((M - 1) / 2.0))
+            num_paired_subset_sizes = np.int64(np.floor((M - 1) / 2.0))
             weight_vector = np.array([(M - 1.0) / (i * (M - i))
                                       for i in range(1, num_subset_sizes + 1)])
             weight_vector[:num_paired_subset_sizes] *= 2

--- a/plugins/_Pre_Process/_Create_Dataset/object_detection_centernet_util/__init__.py
+++ b/plugins/_Pre_Process/_Create_Dataset/object_detection_centernet_util/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Sony Group Corporation.
+# Copyright 2021,2022,2023 Sony Group Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ class ObjectRect:
             self.rect = np.array([XYWH[0] - XYWH[2] * 0.5, XYWH[1] - XYWH[3]
                                   * 0.5, XYWH[0] + XYWH[2] * 0.5, XYWH[1] + XYWH[3] * 0.5])
         else:
-            self.rect = np.full((4,), 0.0, dtype=np.float)
+            self.rect = np.full((4,), 0.0, dtype=np.float64)
 
     def clip(self):
         return ObjectRect(LRTB=self.rect.clip(0.0, 1.0))
@@ -285,7 +285,7 @@ def convert_image(process_dict):
     grid_h = height // grid_size
 
     region_array = np.full(
-        (1, grid_h, grid_w, 4), 0.0, dtype=np.float)
+        (1, grid_h, grid_w, 4), 0.0, dtype=np.float64)
 
     hm = np.zeros((num_class, grid_h, grid_w), dtype=np.float32)
 


### PR DESCRIPTION
The latest numpy drops some dtype names.
This PR fixes these issues.